### PR TITLE
Refactor QueryableExtensions and update version

### DIFF
--- a/src/GridifyExtensions/Extensions/QueryableExtensions.cs
+++ b/src/GridifyExtensions/Extensions/QueryableExtensions.cs
@@ -87,7 +87,7 @@ public static class QueryableExtensions
 
         var item = await query
             .ApplyFiltering(model, mapper)
-            .Select(CreateSelector<TEntity>(model.PropertyName))
+            .Select(mapper.GetExpression(model.PropertyName))
             .FirstOrDefaultAsync(cancellationToken);
 
         if (item is null)
@@ -123,7 +123,7 @@ public static class QueryableExtensions
 
         var item = await query
             .ApplyFiltering(gridifyModel, mapper)
-            .Select(CreateSelector<TEntity>(model.PropertyName))
+            .Select(mapper.GetExpression(model.PropertyName))
             .FirstOrDefaultAsync(cancellationToken);
 
         if (item is null)
@@ -171,14 +171,5 @@ public static class QueryableExtensions
                     .Name ?? x.To.Body.Type.Name
                     : x.To.Body.Type.Name,
         });
-    }
-
-    private static Expression<Func<T, object>> CreateSelector<T>(string propertyName)
-    {
-        var parameter = Expression.Parameter(typeof(T), "x");
-        var property = Expression.Property(parameter, propertyName);
-        var converted = Expression.Convert(property, typeof(object));
-
-        return Expression.Lambda<Func<T, object>>(converted, parameter);
     }
 }

--- a/src/GridifyExtensions/GridifyExtensions.csproj
+++ b/src/GridifyExtensions/GridifyExtensions.csproj
@@ -8,7 +8,7 @@
         <PackageReadmeFile>Readme.md</PackageReadmeFile>
         <Authors>Pandatech</Authors>
         <Copyright>MIT</Copyright>
-        <Version>1.5.1</Version>
+        <Version>1.5.2</Version>
         <PackageId>Pandatech.GridifyExtensions</PackageId>
         <Title>Pandatech.Gridify.Extensions</Title>
         <PackageTags>Pandatech, library, Gridify, Pagination, Filters</PackageTags>


### PR DESCRIPTION
Replaced CreateSelector<TEntity> with mapper.GetExpression in QueryableExtensions.cs. Removed CreateSelector<TEntity> method. Updated project version to 1.5.2 in GridifyExtensions.csproj.