### PR TITLE
Add custom FlagOperator for flag-based filtering

### DIFF
--- a/src/GridifyExtensions/Extensions/WebApplicationBuilderExtensions.cs
+++ b/src/GridifyExtensions/Extensions/WebApplicationBuilderExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using Gridify;
 using GridifyExtensions.Models;
+using GridifyExtensions.Operators;
 using Microsoft.AspNetCore.Builder;
 using System.Reflection;
 
@@ -22,8 +23,9 @@ public static class WebApplicationBuilderExtensions
    private static void AddGridify(Assembly[] assemblies)
    {
       GridifyGlobalConfiguration.EnableEntityFrameworkCompatibilityLayer();
+      GridifyGlobalConfiguration.CustomOperators.Register<FlagOperator>();
 
-      QueryableExtensions.EntityGridifyMapperByType =
+        QueryableExtensions.EntityGridifyMapperByType =
          assemblies.SelectMany(assembly => assembly
                                            .GetTypes()
                                            .Where(t => t.IsClass

--- a/src/GridifyExtensions/GridifyExtensions.csproj
+++ b/src/GridifyExtensions/GridifyExtensions.csproj
@@ -8,13 +8,13 @@
         <PackageReadmeFile>Readme.md</PackageReadmeFile>
         <Authors>Pandatech</Authors>
         <Copyright>MIT</Copyright>
-        <Version>1.6.5</Version>
+        <Version>1.7.0</Version>
         <PackageId>Pandatech.GridifyExtensions</PackageId>
         <Title>Pandatech.Gridify.Extensions</Title>
         <PackageTags>Pandatech, library, Gridify, Pagination, Filters</PackageTags>
         <Description>Pandatech.Gridify.Extensions simplifies and extends the functionality of the Gridify NuGet package. It provides additional extension methods and functionality to streamline data filtering and pagination, making it more intuitive and powerful to use in .NET applications. Our enhancements ensure more flexibility, reduce boilerplate code, and improve overall developer productivity when working with Gridify.</Description>
         <RepositoryUrl>https://github.com/PandaTechAM/be-lib-gridify-extensions</RepositoryUrl>
-        <PackageReleaseNotes>Removed AsNoTracking from ApplyFilter methods</PackageReleaseNotes>
+        <PackageReleaseNotes>Added new operator for supporting flag based filtering</PackageReleaseNotes>
     </PropertyGroup>
  
     <ItemGroup>

--- a/src/GridifyExtensions/Operators/FlagOperator.cs
+++ b/src/GridifyExtensions/Operators/FlagOperator.cs
@@ -1,0 +1,19 @@
+﻿using Gridify.Syntax;
+using System.Linq.Expressions;
+
+namespace GridifyExtensions.Operators
+{
+    internal class FlagOperator : IGridifyOperator
+    {
+        public string GetOperator()
+        {
+            return "#hasFlag";
+        }
+
+        public Expression<OperatorParameter> OperatorHandler()
+        {
+
+            return (prop, value) => ((int)prop & (int)value) == (int)value;
+        }
+    }
+}


### PR DESCRIPTION
Introduce a new custom operator `FlagOperator` for flag-based filtering in the GridifyExtensions library. Register `FlagOperator` with `GridifyGlobalConfiguration.CustomOperators` in `WebApplicationBuilderExtensions.cs`. Update package version in `GridifyExtensions.csproj` from `1.6.5` to `1.7.0` and update release notes to reflect the new feature. Add `FlagOperator.cs` defining the `FlagOperator` class implementing the `IGridifyOperator` interface for `#hasFlag` operator.