### PR TITLE
Update total count logic and version to 2.0.5

### DIFF
--- a/src/GridifyExtensions/Extensions/QueryableExtensions.cs
+++ b/src/GridifyExtensions/Extensions/QueryableExtensions.cs
@@ -23,9 +23,9 @@ public static class QueryableExtensions
 
       query = query.ApplyFilteringAndOrdering(model, mapper);
 
-      var totalCount = await query.CountAsync(cancellationToken);
-
       var dtoQuery = query.Select(selectExpression);
+
+      var totalCount = await dtoQuery.CountAsync(cancellationToken);
 
       dtoQuery = dtoQuery.ApplyPaging(model.Page, model.PageSize);
 

--- a/src/GridifyExtensions/GridifyExtensions.csproj
+++ b/src/GridifyExtensions/GridifyExtensions.csproj
@@ -8,13 +8,13 @@
         <PackageReadmeFile>Readme.md</PackageReadmeFile>
         <Authors>Pandatech</Authors>
         <Copyright>MIT</Copyright>
-        <Version>2.0.4</Version>
+        <Version>2.0.5</Version>
         <PackageId>Pandatech.GridifyExtensions</PackageId>
         <Title>Pandatech.Gridify.Extensions</Title>
         <PackageTags>Pandatech, library, Gridify, Pagination, Filters</PackageTags>
         <Description>Pandatech.Gridify.Extensions simplifies and extends the functionality of the Gridify NuGet package. It provides additional extension methods and functionality to streamline data filtering and pagination, making it more intuitive and powerful to use in .NET applications. Our enhancements ensure more flexibility, reduce boilerplate code, and improve overall developer productivity when working with Gridify.</Description>
         <RepositoryUrl>https://github.com/PandaTechAM/be-lib-gridify-extensions</RepositoryUrl>
-        <PackageReleaseNotes>Support case insensitive filtering by default</PackageReleaseNotes>
+        <PackageReleaseNotes>Count issue for deleted relations fix</PackageReleaseNotes>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Refactor `QueryableExtensions` to calculate total count from `dtoQuery` after applying the select expression, and apply paging to `dtoQuery`.

Update `GridifyExtensions.csproj` version from 2.0.4 to 2.0.5 and modify release notes to address a count issue for deleted relations.